### PR TITLE
chore: bump lune version

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -3,4 +3,4 @@
 
 # To add a new tool, add an entry to this table.
 [tools]
-lune = "filiptibell/lune@0.7.6"
+lune = "filiptibell/lune@0.7.11"


### PR DESCRIPTION
The new lune version includes the latest version of rbx_cookie which is required to fix the latest roblox cookie format.